### PR TITLE
Build all supported NCCL plugin versions found in nccl_net.h.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AX_CHECK_ENABLE_DEBUG([no])
 AC_PROG_CC
 AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
+AC_PROG_SED
 AM_PROG_AR
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -47,7 +48,8 @@ AC_ARG_WITH([nccl],
             AC_HELP_STRING([--with-nccl=PATH], [Path to non-standard NCCL installation]),
             [AS_IF([test -d $withval/lib64], [nccl_libdir="lib64"], [nccl_libdir="lib"])
              CFLAGS="-I$withval/include $CFLAGS"
-             LDFLAGS="-L$withval/$nccl_libdir $LDFLAGS"],
+             LDFLAGS="-L$withval/$nccl_libdir $LDFLAGS"
+             NCCL_INCLUDE_DIR="$withval/include"],
             [])
 
 AC_ARG_WITH([mpi],
@@ -72,6 +74,19 @@ AS_IF([test "x${enable_trace}" = "xyes" ],
        [trace=0
        AC_MSG_RESULT(no)])
 AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-trace, 0 otherwise])
+
+# Get supported plugin versions from nccl_net.h header
+PLUGIN_VERSION_LIST=`$SED -rn 's/.*ncclNet_v(\S*)_t;/\1/p' $NCCL_INCLUDE_DIR/nccl_net.h | uniq`
+PLUGIN_VERSION_LIBS=""
+for version in $PLUGIN_VERSION_LIST
+do
+  if [[ $version -gt 1 ]]
+  then
+    echo "Found supported NCCL plugin version $version in nccl_net.h..."
+    PLUGIN_VERSION_LIBS="$PLUGIN_VERSION_LIBS libv$version.la "
+  fi
+done
+AC_SUBST([PLUGIN_VERSION_LIBS])
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h cuda_runtime.h], [],[

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -70,9 +70,9 @@ extern "C" {
 #define NCCL_OFI_FLUSH_SIZE	4
 
 /* NCCL OFI lock for concurrency */
-pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Logger Function */
-ncclDebugLogger_t ofi_log_function = NULL;
+static ncclDebugLogger_t ofi_log_function = NULL;
 
 typedef enum nccl_ofi_req_state {
 	NCCL_OFI_REQ_CREATED = 0,
@@ -120,7 +120,6 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 struct nccl_ofi_req;
 typedef struct nccl_ofi_req nccl_ofi_req_t;
 
@@ -138,7 +137,6 @@ typedef struct save_comm_state {
 	nccl_ofi_req_t *req;
 	nccl_ofi_comm_stage_t stage;
 } save_comm_state_t;
-#endif
 
 typedef struct listenComm {
 	uint64_t tag;
@@ -146,12 +144,10 @@ typedef struct listenComm {
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Saves temporary state when creating receive communicator object */
 	save_comm_state_t state;
 	/* Saves peer address information */
 	void *buffer;
-#endif
 } listenComm_t;
 
 typedef struct comm {
@@ -190,10 +186,8 @@ typedef struct nccl_ofi_req {
 	/* Associated Device ID */
 	int dev;
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Number of receives associated with request */
 	int num_recvs;
-#endif
 
 	/* Size of completed request */
 	size_t size;

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -14,8 +14,8 @@ extern "C" {
 #include <string.h>
 
 #define OFI_NCCL_PARAM_INT(name, env, default_value) \
-pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
-int64_t ofi_nccl_##name() { \
+static pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+static int64_t ofi_nccl_##name() { \
     assert(default_value != -1LL); \
     static int64_t value = -1LL; \
     pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
@@ -43,8 +43,8 @@ int64_t ofi_nccl_##name() { \
 }
 
 #define OFI_NCCL_PARAM_STR(name, env, default_value) \
-pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
-char *ofi_nccl_##name() { \
+static pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+static char *ofi_nccl_##name() { \
     assert(default_value != NULL); \
     static char *value = NULL; \
     pthread_mutex_lock(&ofi_nccl_param_lock_##name); \

--- a/include/stack.h
+++ b/include/stack.h
@@ -38,7 +38,7 @@ exit:
  * @brief	Free given stack
  */
 
-void free_stack(stack_t *stack)
+static void free_stack(stack_t *stack)
 {
 	if (!stack)
 		return;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,6 @@ AM_LDFLAGS = -lcudart
 lib_LTLIBRARIES = libnccl-net.la
 libnccl_net_la_SOURCES =
 
-#libnccl_net_la_LIBADD = libv4.la libv5.la
 libnccl_net_la_LIBADD = $(PLUGIN_VERSION_LIBS)
 libnccl_net_la_DEPENDENCIES = $(PLUGIN_VERSION_LIBS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,4 +9,30 @@ AM_CFLAGS += -I$(top_srcdir)/include
 AM_LDFLAGS = -lcudart
 
 lib_LTLIBRARIES = libnccl-net.la
-libnccl_net_la_SOURCES = nccl_ofi_net.c
+libnccl_net_la_SOURCES =
+
+#libnccl_net_la_LIBADD = libv4.la libv5.la
+libnccl_net_la_LIBADD = $(PLUGIN_VERSION_LIBS)
+libnccl_net_la_DEPENDENCIES = $(PLUGIN_VERSION_LIBS)
+
+EXTRA_LTLIBRARIES =
+
+libv2_la_SOURCES = nccl_ofi_net.c
+libv2_la_CFLAGS = $(AM_CFLAGS) -DPLUGIN_VERSION=2
+EXTRA_LTLIBRARIES += libv2.la
+
+libv3_la_SOURCES = nccl_ofi_net.c
+libv3_la_CFLAGS = $(AM_CFLAGS) -DPLUGIN_VERSION=3
+EXTRA_LTLIBRARIES += libv3.la
+
+libv4_la_SOURCES = nccl_ofi_net.c
+libv4_la_CFLAGS = $(AM_CFLAGS) -DPLUGIN_VERSION=4
+EXTRA_LTLIBRARIES += libv4.la
+
+libv5_la_SOURCES = nccl_ofi_net.c
+libv5_la_CFLAGS = $(AM_CFLAGS) -DPLUGIN_VERSION=5
+EXTRA_LTLIBRARIES += libv5.la
+
+libv6_la_SOURCES = nccl_ofi_net.c
+libv6_la_CFLAGS = $(AM_CFLAGS) -DPLUGIN_VERSION=6
+EXTRA_LTLIBRARIES += libv6.la

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -14,23 +14,50 @@
 #include <stack.h>
 #include <nccl_ofi_param.h>
 
+#if (PLUGIN_VERSION == 2)
+typedef ncclNet_v2_t ncclNet_vx_t;
+#define PLUGIN_SYMBOL ncclNetPlugin_v2
+#elif (PLUGIN_VERSION == 3)
+typedef ncclNetProperties_v3_t ncclNetProperties_vx_t;
+typedef ncclNet_v3_t ncclNet_vx_t;
+#define PLUGIN_SYMBOL ncclNetPlugin_v3
+#elif (PLUGIN_VERSION == 4)
+typedef ncclNetProperties_v4_t ncclNetProperties_vx_t;
+typedef ncclNet_v4_t ncclNet_vx_t;
+#define PLUGIN_SYMBOL ncclNetPlugin_v4
+#elif (PLUGIN_VERSION == 5)
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 14, 0))
+// In NCCL 2.14.x, nccl_net.h header does not create alias for
+// ncclNetPropertives_v5_t so the v6 version is used here.
+typedef ncclNetProperties_v6_t ncclNetProperties_vx_t;
+#else
+typedef ncclNetProperties_v5_t ncclNetProperties_vx_t;
+#endif
+typedef ncclNet_v5_t ncclNet_vx_t;
+#define PLUGIN_SYMBOL ncclNetPlugin_v5
+#elif (PLUGIN_VERSION == 6)
+typedef ncclNetProperties_v6_t ncclNetProperties_vx_t;
+typedef ncclNet_v6_t ncclNet_vx_t;
+#define PLUGIN_SYMBOL ncclNetPlugin_v6
+#endif
+
 static uint32_t libversion = 0;
 /* NICs info list for a provider */
-struct fi_info* ofi_info_list = NULL;
+static struct fi_info* ofi_info_list = NULL;
 /* Number of NICs */
-int ofi_ndevices = -1;
+static int ofi_ndevices = -1;
 /* NCCL OFI component array for all NICs */
-nccl_ofi_t **nccl_ofi_component = NULL;
+static nccl_ofi_t **nccl_ofi_component = NULL;
 /* Indicates if memory registration of local buffers is required */
-bool local_mr = false;
+static bool local_mr = false;
 /* Indicates if memory registration of device buffers is required */
-bool hmem_mr = false;
+static bool hmem_mr = false;
 /* Indicates if GPUDirect is supported by libfabric provider */
-bool support_gdr = true;
+static bool support_gdr = true;
 /* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
  * to flush data to the GPU. Note, CUDA flush support is not supported on all
  * platforms and should be disabled by default */
-bool cuda_flush = false;
+static bool cuda_flush = false;
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -92,7 +119,7 @@ exit:
 /*
  * @brief	Release free list for NCCL OFI requests
  */
-void free_ofi_fl(free_list_t *nccl_ofi_req_fl)
+static void free_ofi_fl(free_list_t *nccl_ofi_req_fl)
 {
 	if (!nccl_ofi_req_fl)
 		return;
@@ -867,7 +894,7 @@ exit:
 /*
  * @brief	Release various libfabric resources.
  */
-void release_nccl_ofi_component(int dev)
+static void release_nccl_ofi_component(int dev)
 {
 	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[dev];
 
@@ -1233,9 +1260,9 @@ static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 	return ncclSuccess;
 }
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+#if (PLUGIN_VERSION >= 3) /* Support NCCL v2.6 */
 static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
-					  ncclNetProperties_t *props)
+					  ncclNetProperties_vx_t *props)
 {
 	ncclResult_t ret = ncclSuccess;
 
@@ -1250,7 +1277,7 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 	props->maxComms = nic_prov->domain_attr->ep_cnt;
 	props->guid = dev;
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 	/*
 	 * Maximum number of grouped receives. Currently, we set it to 1 to
 	 * maintain single send/recv semantics (similar to NCCL versions < v2.12).
@@ -1274,10 +1301,10 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 	return ret;
 }
 
-static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_t *props)
+static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_vx_t *props)
 {
 	ncclResult_t ret = ncclSuccess;
-	ncclNetProperties_t dev_props = {0};
+	ncclNetProperties_vx_t dev_props = {0};
 	struct fi_info *nic_prov = NULL;
 	struct fid_nic *nic_info = NULL;
 
@@ -1445,7 +1472,7 @@ exit:
 	return ret;
 }
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 /*
  * @brief	Creates send communication for a peer
  *
@@ -1938,7 +1965,7 @@ exit:
 }
 #endif
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 /*
  * @brief	Allocate a request to receive peer connection message
  *
@@ -2481,7 +2508,7 @@ exit:
 	return ret;
 }
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 			      int tag, void *mhandle, void** request)
 #else
@@ -2576,7 +2603,7 @@ exit:
 	return ret;
 }
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 static ncclResult_t ofi_irecv(void* recvComm, int n, void** buffers, int* sizes,
 			      int *tags, void** mhandles, void** request)
 #else
@@ -2622,7 +2649,7 @@ static ncclResult_t ofi_irecv(void* recvComm, void* buffer, int size,
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 	req->num_recvs = n;
 
 	if (OFI_UNLIKELY(mhandles == NULL)) {
@@ -2741,7 +2768,7 @@ exit:
 	return ret;
 }
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 static ncclResult_t ofi_iflush(void* recvComm, int n, void** buffers, int* sizes,
 			       void** mhandles, void** request)
 #else
@@ -2784,7 +2811,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* buffer, int size,
 		goto exit;
 	}
 
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 	/* Plugin only supports one receive per request */
 	assert(n == 1);
 
@@ -2906,7 +2933,7 @@ exit:
 	return ret;
 }
 
-#if (NCCL_VERSION_CODE < NCCL_VERSION(2, 8, 0))
+#if (PLUGIN_VERSION < 4)
 static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 			      void *mhandle)
 {
@@ -3042,29 +3069,31 @@ exit:
 	return ret;
 }
 
-const ncclNet_t NCCL_PLUGIN_SYMBOL = {
+const ncclNet_vx_t PLUGIN_SYMBOL = {
 	.name = "AWS Libfabric",
 	.init = ofi_init,
 	.devices = ofi_devices,
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+#if (PLUGIN_VERSION >= 3) /* Support NCCL v2.6 */
 	.getProperties = ofi_getProperties,
 #else /* Support NCCL version >= v2.4.x and < v2.6.x */
 	.pciPath = ofi_pciPath,
 	.ptrSupport = ofi_ptrSupport,
 #endif
 	.listen = ofi_listen,
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+#if (PLUGIN_VERSION >= 5) /* Support NCCL v2.12 */
 	.connect = ofi_iconnect,
 	.accept = ofi_iaccept,
 #else
 	.connect = ofi_connect,
 	.accept = ofi_accept,
 #endif
+#if (PLUGIN_VERSION > 1)
 	.regMr = ofi_regMr,
 	.deregMr = ofi_deregMr,
+#endif
 	.isend = ofi_isend,
 	.irecv = ofi_irecv,
-#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
+#if (PLUGIN_VERSION >= 4) /* Support NCCL v2.8 */
 	.iflush = ofi_iflush,
 #else
 	.flush = ofi_flush,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1080,6 +1080,7 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	ofi_log_function = logFunction;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using " PACKAGE_STRING);
+	NCCL_OFI_INFO(NCCL_INIT, "Using NCCL plugin version %d", PLUGIN_VERSION);
 
 	if (ofi_nccl_cuda_flush_enable()) {
 #if CUDART_VERSION < 11030


### PR DESCRIPTION
*Description of changes:*
This PR modifies the build process to package multiple NCCL plugin versions into the final shared library. In the current build process, only the latest NCCL plugin available in the supplied NCCL installation at build time is compiled. NCCL is only forward compatible with NCCL plugin versions, so this limits backwards compatibility (e.g. for a plugin built against NCCL 2.13+, a v6 plugin is built which cannot be used with earlier NCCL versions).

To build multiple plugin versions I do the following:
1. During configuration, parse the `nccl_net.h` header of the supplied NCCL installation to determine what plugin versions are available.
2. Run a compilation pass for each plugin version, resulting in a `libv*.la` library for each version to support.
3. Package all the `libv*.la` files into the final `libnccl-net.so`. 

To enable multiple complication passes and avoid conflicts, I had to add the `static` qualifier to several variables and functions that were missing it.

As an additional note, this PR limits support down to NCCL plugin v2, which is consistent with the existing support range (down to NCCL 2.4). The v1 plugin has different signatures that are incompatible with the existing implementations.  
